### PR TITLE
Удалить избыточный STATIC FILE DETECTION из index.php

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/ideav/newui/issues/19
-Your prepared branch: issue-19-f2b18f34af8b
-Your prepared working directory: /tmp/gh-issue-solver-1771846311754
-Your forked repository: konard/ideav-newui
-Original repository (upstream): ideav/newui
-
-Proceed.


### PR DESCRIPTION
## Проблема

В `index.php` была секция **STATIC FILE DETECTION** с функцией `isStaticFile()`, которая проверяла, существует ли запрошенный файл на диске, и отдавала его через PHP.

Однако это было полностью избыточно: `.htaccess` уже содержит правило Apache:

\`\`\`apache
RewriteCond %{REQUEST_FILENAME} -f
RewriteRule ^ - [L]
\`\`\`

Это означает, что `index.php` вызывается **только** тогда, когда файл или директория **не найдены**. Статические файлы Apache обслуживает напрямую, и они никогда не достигают `index.php`.

Fixes #19

## Изменения

- Удалена функция `isStaticFile()` и секция `STATIC FILE DETECTION`
- Удалена обработка маршрутов типа `'static'` из `detectRoute()`
- Удалена логика обслуживания статических файлов из основной маршрутизации
- Добавлен тип маршрута `'not_found'` для нераспознанных путей
- Обновлён docblock `index.php` с точным описанием его роли