### PR TITLE
Fix PHP 8.3 compatibility issues in index.php

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,3 @@ Your forked repository: konard/ideav-newui
 Original repository (upstream): ideav/newui
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/ideav/newui/issues/37
-Your prepared branch: issue-37-2eebb8c15ee3
-Your prepared working directory: /tmp/gh-issue-solver-1772097833577
-Your forked repository: konard/ideav-newui
-Original repository (upstream): ideav/newui
-
-Proceed.
-
-
-Run timestamp: 2026-02-26T09:23:59.432Z


### PR DESCRIPTION
## Summary

Fixes PHP errors reported in production logs from issue #37.

The production `index.php` (uploaded as `index0226.php`) had the following errors that are fixed in this PR:

### Fixes

1. **PHP Deprecated: `preg_match()` and `strlen()` passing null** (lines 1340, 1362, 1364)
   - Database columns `mask`, `exp`, `del` can be `NULL` (from `LEFT JOIN`)
   - Added null coalescing operator (`?? ''`) for `$row["exp"]` and `$row["del"]`
   - Extracted `$row["mask"]` into local `$mask` variable with null coalescing

2. **PHP Fatal error: Unsupported operand types: string - int** (line 1432)
   - After `preg_replace()`, `$val` becomes a string (e.g. `"26.02.2026"`)
   - The `if($val > 10000)` condition was true due to PHP's loose comparison between string and int
   - Fixed by adding `is_numeric($val)` guard and `(int)$val` cast before arithmetic

3. **PHP Warning: Undefined variable `$par_orig`** (line 2077)
   - `$par_orig` was only assigned inside a nested `if(isset($repJoin))` block
   - On iterations where `$repJoin` is not set, `$par_orig` was undefined
   - Fixed by initializing `$par_orig = $par_alias` alongside `$par` and `$par_alias` at the start of each loop iteration

### Verification

- PHP 8.3 syntax check passes: `php -l index.php` → "No syntax errors detected"

Fixes #37